### PR TITLE
Adding string parsing to Weekday.

### DIFF
--- a/lib/src/tempo/weekday.dart
+++ b/lib/src/tempo/weekday.dart
@@ -25,4 +25,10 @@ enum Weekday {
   ///
   /// US weekdays are numbered 0=Sunday to 6=Saturday.
   int get us => index % 7;
+
+  /// Parses a string to a weekday.
+  ///
+  /// Takes a lower-case weekday name in English and returns the respective enumerated value.
+  factory Weekday.parse(String string) =>
+      Weekday.values.skip(1).where((val) => val.name == string).single;
 }


### PR DESCRIPTION
This closes #4 as two-letter representations are not planned.